### PR TITLE
Fix OAuth token validator name

### DIFF
--- a/src/api/google-api.ts
+++ b/src/api/google-api.ts
@@ -165,7 +165,7 @@ export const deleteDriveFile = async (fileId: string, accessToken: string) => {
   }
 };
 
-export const validateGoogleOath2AccessToken = async (accessToken: string) => {
+export const validateGoogleOAuth2AccessToken = async (accessToken: string) => {
   const response = await fetch(
     `https://oauth2.googleapis.com/tokeninfo?access_token=${accessToken}`
   );

--- a/src/components/GoogleSync/GoogleSync.tsx
+++ b/src/components/GoogleSync/GoogleSync.tsx
@@ -9,7 +9,7 @@ import {
   createDriveFile,
   deleteDriveFile,
   updateDriveFileName,
-  validateGoogleOath2AccessToken,
+  validateGoogleOAuth2AccessToken,
 } from '@api/google-api';
 import { getFiles, stateToFile } from '@utils/google-api';
 import createGoogleCloudStorage from '@store/storage/GoogleCloudStorage';
@@ -40,7 +40,7 @@ const GoogleSync = ({ clientId }: { clientId: string }) => {
   const [files, setFiles] = useState<GoogleFileResource[]>([]);
 
   const initialiseState = async (_googleAccessToken: string) => {
-    const validated = await validateGoogleOath2AccessToken(_googleAccessToken);
+    const validated = await validateGoogleOAuth2AccessToken(_googleAccessToken);
     if (validated) {
       try {
         const _files = await getFiles(_googleAccessToken);

--- a/src/store/storage/GoogleCloudStorage.ts
+++ b/src/store/storage/GoogleCloudStorage.ts
@@ -5,7 +5,7 @@ import {
   deleteDriveFile,
   getDriveFile,
   updateDriveFileDebounced,
-  validateGoogleOath2AccessToken,
+  validateGoogleOAuth2AccessToken,
 } from '@api/google-api';
 
 const createGoogleCloudStorage = <S>(): PersistStorage<S> | undefined => {
@@ -14,7 +14,7 @@ const createGoogleCloudStorage = <S>(): PersistStorage<S> | undefined => {
   if (!accessToken || !fileId) return;
 
   try {
-    const authenticated = validateGoogleOath2AccessToken(accessToken);
+    const authenticated = validateGoogleOAuth2AccessToken(accessToken);
     if (!authenticated) return;
   } catch (e) {
     // prevent error if the storage is not defined (e.g. when server side rendering a page)


### PR DESCRIPTION
## Summary
- rename `validateGoogleOath2AccessToken` to `validateGoogleOAuth2AccessToken`
- update GoogleSync and cloud storage modules

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6847e498dc788328a15599ab6aca8d71